### PR TITLE
Fix nginx stack.  Use Dockerfile to copy static web content into image before launch. S

### DIFF
--- a/docker-compose/nginx/Dockerfile
+++ b/docker-compose/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:alpine
 
 #COPY nginx.conf /etc/nginx/nginx.conf
 
-COPY ./www /var/www
+COPY ./www/html /usr/share/nginx/html
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/docker-compose/nginx/Dockerfile
+++ b/docker-compose/nginx/Dockerfile
@@ -1,10 +1,11 @@
 FROM nginx:alpine
 
-# Expost port 80
-EXPOSE 80
-
 #COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY ./www /var/www
 
-CMD ["nginx"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+STOPSIGNAL SIGQUIT
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose/nginx/Dockerfile
+++ b/docker-compose/nginx/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:alpine
+
+# Expost port 80
+EXPOSE 80
+
+#COPY nginx.conf /etc/nginx/nginx.conf
+
+COPY ./www /var/www
+
+CMD ["nginx"]

--- a/docker-compose/nginx/docker-compose.yml
+++ b/docker-compose/nginx/docker-compose.yml
@@ -25,14 +25,13 @@ version: "3.3"
 #    http://<common-lan-local-hostname>/${SUBDOMAIN:-www}   (private LAN only)                (path-based, multiple hostnames accepted; see below)
 services:
   www:
-    image: "nginx:alpine"    
+    image: "local/www-static"
+    build: .
+    pull_policy: build
     hostname: ${WWW_HOSTNAME:-${SUBDOMAIN:-www}}
     networks:
       - traefik                # The network through which traefik forwards requests to our service
     restart: always            # This container will be restarted when this host reboots or docker is restarted
-    volumes:
-      - ./www/html:/usr/share/nginx/html:ro
-    
     labels:
       - "traefik.enable=true"   # tells traefik that this container should be reverse-proxied
 

--- a/docker-compose/nginx/docker-compose.yml
+++ b/docker-compose/nginx/docker-compose.yml
@@ -25,6 +25,7 @@ version: "3.3"
 #    http://<common-lan-local-hostname>/${SUBDOMAIN:-www}   (private LAN only)                (path-based, multiple hostnames accepted; see below)
 services:
   www:
+    #image: "nginx:alpine"
     image: "local/www-static"
     build: .
     pull_policy: build

--- a/docker-compose/nginx/docker-compose.yml
+++ b/docker-compose/nginx/docker-compose.yml
@@ -17,26 +17,12 @@ version: "3.3"
 #                            The "Host" Traefik rule expression that will match all HTTP hostnames for the private LAN-only
 #                                 apps.
 #
-#    SHARED_LAN_APP_HTTPS_HOST_RULE
-#                            The "Host" Traefik rule expression that will match all HTTPS hostnames for the private LAN-only
-#                                 apps.
-#
 # This stack serves:
-#    http://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}          (public internet or private LAN)  (hostname based)
-#    https://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}         (public internet or private LAN)  (hostname based)
-#    http://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-www}        (public internet or private LAN)  (path-based, handled by <common-lan-local-hostname> router; see below)
-#    https://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-www}       (public internet or private LAN)  (path-based)
-#    http://${SHARED_LAN_APP_DNS_NAME}/${SUBDOMAIN:-www}    (private LAN)                     (path-based, handled by <common-lan-local-hostname> router; see below)
-#    https://${SHARED_LAN_APP_DNS_NAME}/${SUBDOMAIN:-www}   (private LAN only)                (path-based)
+#    https://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}         (public internet)                 (hostname based)
+#    https://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-www}       (public internet)                 (path-based)
+#    http://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}          (private LAN only)                (hostname based, requires /etc/hosts entry)
+#    http://${SHARED_LAN_APP_DNS_NAME}/${SUBDOMAIN:-www}    (private LAN only)                (path-based, handled by <common-lan-local-hostname> router; see below)
 #    http://<common-lan-local-hostname>/${SUBDOMAIN:-www}   (private LAN only)                (path-based, multiple hostnames accepted; see below)
-#
-
-# Prerequisites:
-#   Prerequisites common to all stacks (only done once when traefik is initially set up):
-#     * The traefik docker-compose stack has been installed and runs on this host.
-#     * The portainer docker-compose stack has been installed and runs on this host.
-#     * This stack is launched within Portainer and can make use of Portainer's injected environment variables.
-#
 services:
   www:
     image: "nginx:alpine"    
@@ -45,7 +31,7 @@ services:
       - traefik                # The network through which traefik forwards requests to our service
     restart: always            # This container will be restarted when this host reboots or docker is restarted
     volumes:
-      - /var/www/html:/usr/share/nginx/html:ro
+      - ./www/html:/usr/share/nginx/html:ro
     
     labels:
       - "traefik.enable=true"   # tells traefik that this container should be reverse-proxied
@@ -53,80 +39,21 @@ services:
       # Middleware that will strip off the /${SUBDOMAIN:-www} prefix before forwarding to the www service (used by multiple routers)
       - "traefik.http.middlewares.${SUBDOMAIN:-www}-strip-prefix.stripPrefix.prefixes=/${SUBDOMAIN:-www}"
 
-      # NOTE: If the routes below seem unnecessarily complex, it is because they are separated into multiple routers to allow detailed
-      # routing info to be included in a "X-Route-Info" header that is passed to the www service and then returned in the
-      # www response. This is useful for debugging and understanding traefik routing behavior. If you don't need this, it
-      # is possible to greatly simplify the routing configuration; e.g., by serving multiple entrypoints and hostnames with
-      # a single router.
-
       # -----------------------------------------
       # A router for https://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}, on the public internet entrypoint
       - "traefik.http.routers.${SUBDOMAIN:-www}-https-public.entrypoints=websecure"
       - "traefik.http.routers.${SUBDOMAIN:-www}-https-public.rule=Host(`${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-https-public-headers.headers.customrequestheaders.X-Route-Info=entrypoint=websecure; router=${SUBDOMAIN:-www}-https-public"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-public.middlewares=${SUBDOMAIN:-www}-https-public-headers"
-      # -----------------------------------------
-      # A router for https://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}, on the local lan entrypoint
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-private.entrypoints=lanwebsecure"
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-private.rule=Host(`${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-https-private-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanwebsecure; router=${SUBDOMAIN:-www}-https-private"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-private.middlewares=${SUBDOMAIN:-www}-https-private-headers"
-
-      # -----------------------------------------
-      # A router for http://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}, on the public internet entrypint
-      - "traefik.http.routers.${SUBDOMAIN:-www}-http-public.entrypoints=web"
-      - "traefik.http.routers.${SUBDOMAIN:-www}-http-public.rule=Host(`${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-http-public-headers.headers.customrequestheaders.X-Route-Info=entrypoint=web, router=${SUBDOMAIN:-www}-http-public"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-http-public.middlewares=${SUBDOMAIN:-www}-http-public-headers"
       # -----------------------------------------
       # A router for http://${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}, on the local LAN entrypoint
+      # Note: to use this entry point the client must have an entry in /etc/hosts
       - "traefik.http.routers.${SUBDOMAIN:-www}-http-private.entrypoints=lanweb"
       - "traefik.http.routers.${SUBDOMAIN:-www}-http-private.rule=Host(`${SUBDOMAIN:-www}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-http-private-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanweb, router=${SUBDOMAIN:-www}-http-private"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-http-private.middlewares=${SUBDOMAIN:-www}-http-private-headers"
       # -----------------------------------------
-      # A router for http(s)://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-www}, on the public internet entrypoint
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-public-path.entrypoints=websecure"
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-public-path.rule=${SHARED_APP_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-www}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-https-shared-public-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=websecure, router=${SUBDOMAIN:-www}-https-shared-public-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-public-path.middlewares=${SUBDOMAIN:-www}-strip-prefix,${SUBDOMAIN:-www}-https-shared-public-path-headers"
-      # -----------------------------------------
-      # A router for https://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-www}, on the local LAN entrypointy
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-private-path.entrypoints=lanwebsecure"
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-private-path.rule=${SHARED_LAN_APP_HTTPS_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-www}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-https-shared-private-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanwebsecure, router=${SUBDOMAIN:-www}-https-shared-private-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-private-path.middlewares=${SUBDOMAIN:-www}-strip-prefix,${SUBDOMAIN:-www}-https-shared-private-path-headers"
-      # -----------------------------------------
-      # A router for http://<common-lan-local-hostname>/${SUBDOMAIN:-www}, on the local LAN entrypoint only
+      # A router for http://<common-lan-app-hostname>/${SUBDOMAIN:-www}, on the local LAN entrypoint only
       - "traefik.http.routers.${SUBDOMAIN:-www}-http-private-path.entrypoints=lanweb"
       - "traefik.http.routers.${SUBDOMAIN:-www}-http-private-path.rule=${SHARED_LAN_APP_HTTP_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-www}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-http-private-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanweb, router=${SUBDOMAIN:-www}-http-private-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-http-private-path.middlewares=${SUBDOMAIN:-www}-strip-prefix,${SUBDOMAIN:-www}-http-private-path-headers"
-
-      # -----------------------------------------
-      # A router for https://${SHARED_LAN_APP_DNS_NAME}/${SUBDOMAIN:-www}, on the local LAN entrypoint only
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-lan-private-path.entrypoints=lanwebsecure"
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-lan-private-path.rule=${SHARED_LAN_APP_HTTPS_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-www}`)"
-      # Following middleware will add a request header that will be displayed by www to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-www}-https-shared-lan-private-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanwebsecure, router=${SUBDOMAIN:-www}-https-shared-lan-private-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-www}-https-shared-lan-private-path.middlewares=${SUBDOMAIN:-www}-strip-prefix,${SUBDOMAIN:-www}-https-shared-lan-private-path-headers"
-      # -----------------------------------------
-
+      # Strip the prefix
+      - "traefik.http.routers.${SUBDOMAIN:-www}-http-private-path.middlewares=${SUBDOMAIN:-www}-strip-prefix"
 
 networks:
 

--- a/docker-compose/nginx/www/html/index.html
+++ b/docker-compose/nginx/www/html/index.html
@@ -1,0 +1,1 @@
+Hello, World of Docker/Traefik/Portainer (from index.html inside homeserver repo)

--- a/docker-compose/photoprism/docker-compose.yml
+++ b/docker-compose/photoprism/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     ## Server port mapping in the format "Host:Container". To use a different port, change the host port on
     ## the left-hand side and keep the container port, e.g. "80:2342" (for HTTP) or "443:2342 (for HTTPS):
     ports:
+      # TODO: Remove this line after debugging. Not needed to access behind Traefik
       - "2342:2342"
     ## Before you start the service, please check the following config options (and change them as needed):
     ## https://docs.photoprism.app/getting-started/config-options/
@@ -39,7 +40,7 @@ services:
       PHOTOPRISM_ADMIN_USER: "admin"                 # admin login username
       PHOTOPRISM_ADMIN_PASSWORD: "insecure"          # initial admin password (8-72 characters)
       PHOTOPRISM_AUTH_MODE: "password"               # authentication mode (public, password)
-      PHOTOPRISM_SITE_URL: "http://photo.sadovskyphoto.net"    # server URL in the format "http(s)://domain.name(:port)/(path)"
+      PHOTOPRISM_SITE_URL: "https://photo.sadovskyphoto.net"    # server URL in the format "http(s)://domain.name(:port)/(path)"
       PHOTOPRISM_DISABLE_TLS: "false"                # disables HTTPS/TLS even if the site URL starts with https:// and a certificate is available
       PHOTOPRISM_DEFAULT_TLS: "true"                 # defaults to a self-signed HTTPS/TLS certificate if no other certificate is available
       PHOTOPRISM_ORIGINALS_LIMIT: 5000               # file size limit for originals in MB (increase for high-res video)
@@ -94,92 +95,35 @@ services:
     working_dir: "/photoprism" # do not change or remove
     ## Storage Folders: "~" is a shortcut for your home directory, "." for the current directory
     volumes:
-      # "/host/folder:/photoprism/folder"                # Example
-      - "~/media/photo:/photoprism/originals"               # Original media files (DO NOT REMOVE)
-      # - "/example/family:/photoprism/originals/family" # *Additional* media folders can be mounted like this
-      # - "~/Import:/photoprism/import"                  # *Optional* base folder from which files can be imported to originals
-      - "./storage:/photoprism/storage"                  # *Writable* storage folder for cache, database, and sidecar files (DO NOT REMOVE)
+      - "${HUB_HOME_DIR}/media/photo:/photoprism/originals"  # Original media files (DO NOT REMOVE)
+      # - "/example/family:/photoprism/originals/family"      # *Additional* media folders can be mounted like this
+      # - "~/Import:/photoprism/import"                       # *Optional* base folder from which files can be imported to originals
+      - "photoprism_storage:/photoprism/storage"              # *Writable* storage folder for cache, database, and sidecar files (DO NOT REMOVE)
 
     hostname: ${PHOTO_HOSTNAME:-${SUBDOMAIN:-photo}}
     restart: always            # This container will be restarted when this host reboots or docker is restarted
     labels:
       - "traefik.enable=true"   # tells traefik that this container should be reverse-proxied
+      - "traefik.http.services.photoprism.loadbalancer.server.port=2342"     # Port 2342 is reverse-proxied
 
-      # Middleware that will strip off the /${SUBDOMAIN:-photo} prefix before forwarding to the photo service (used by multiple routers)
+      # Middleware that will strip off the /${SUBDOMAIN:-www} prefix before forwarding to the www service (used by multiple routers)
       - "traefik.http.middlewares.${SUBDOMAIN:-photo}-strip-prefix.stripPrefix.prefixes=/${SUBDOMAIN:-photo}"
-
-      # NOTE: If the routes below seem unnecessarily complex, it is because they are separated into multiple routers to allow detailed
-      # routing info to be included in a "X-Route-Info" header that is passed to the photo service and then returned in the
-      # photo response. This is useful for debugging and understanding traefik routing behavior. If you don't need this, it
-      # is possible to greatly simplify the routing configuration; e.g., by serving multiple entrypoints and hostnames with
-      # a single router.
 
       # -----------------------------------------
       # A router for https://${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}, on the public internet entrypoint
       - "traefik.http.routers.${SUBDOMAIN:-photo}-https-public.entrypoints=websecure"
       - "traefik.http.routers.${SUBDOMAIN:-photo}-https-public.rule=Host(`${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-https-public-headers.headers.customrequestheaders.X-Route-Info=entrypoint=websecure; router=${SUBDOMAIN:-photo}-https-public"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-public.middlewares=${SUBDOMAIN:-photo}-https-public-headers"
-      # -----------------------------------------
-      # A router for https://${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}, on the local lan entrypoint
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-private.entrypoints=lanwebsecure"
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-private.rule=Host(`${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-https-private-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanwebsecure; router=${SUBDOMAIN:-photo}-https-private"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-private.middlewares=${SUBDOMAIN:-photo}-https-private-headers"
-      # -----------------------------------------
-      # A router for http://${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}, on the public internet entrypint
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-http-public.entrypoints=web"
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-http-public.rule=Host(`${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-http-public-headers.headers.customrequestheaders.X-Route-Info=entrypoint=web, router=${SUBDOMAIN:-photo}-http-public"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-http-public.middlewares=${SUBDOMAIN:-photo}-http-public-headers"
       # -----------------------------------------
       # A router for http://${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}, on the local LAN entrypoint
+      # Note: to use this entry point the client must have an entry in /etc/hosts
       - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private.entrypoints=lanweb"
       - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private.rule=Host(`${SUBDOMAIN:-photo}.${PARENT_DNS_DOMAIN}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-http-private-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanweb, router=${SUBDOMAIN:-photo}-http-private"
-      # Add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private.middlewares=${SUBDOMAIN:-photo}-http-private-headers"
       # -----------------------------------------
-      # A router for http(s)://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-photo}, on the public internet entrypoint
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-public-path.entrypoints=websecure"
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-public-path.rule=${SHARED_APP_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-photo}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-https-shared-public-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=websecure, router=${SUBDOMAIN:-photo}-https-shared-public-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-public-path.middlewares=${SUBDOMAIN:-photo}-strip-prefix,${SUBDOMAIN:-photo}-https-shared-public-path-headers"
-      # -----------------------------------------
-      # A router for https://${SHARED_APP_DNS_NAME}/${SUBDOMAIN:-photo}, on the local LAN entrypointy
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-private-path.entrypoints=lanwebsecure"
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-private-path.rule=${SHARED_LAN_APP_HTTPS_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-photo}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-https-shared-private-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanwebsecure, router=${SUBDOMAIN:-photo}-https-shared-private-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-private-path.middlewares=${SUBDOMAIN:-photo}-strip-prefix,${SUBDOMAIN:-photo}-https-shared-private-path-headers"
-      # -----------------------------------------
-      # A router for http://<common-lan-local-hostname>/${SUBDOMAIN:-photo}, on the local LAN entrypoint only
+      # A router for http://<common-lan-app-hostname>/${SUBDOMAIN:-photo}, on the local LAN entrypoint only
       - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private-path.entrypoints=lanweb"
       - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private-path.rule=${SHARED_LAN_APP_HTTP_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-photo}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-http-private-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanweb, router=${SUBDOMAIN:-photo}-http-private-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private-path.middlewares=${SUBDOMAIN:-photo}-strip-prefix,${SUBDOMAIN:-photo}-http-private-path-headers"
-
-      # -----------------------------------------
-      # A router for https://${SHARED_LAN_APP_DNS_NAME}/${SUBDOMAIN:-photo}, on the local LAN entrypoint only
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-lan-private-path.entrypoints=lanwebsecure"
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-lan-private-path.rule=${SHARED_LAN_APP_HTTPS_HOST_RULE} && PathPrefix(`/${SUBDOMAIN:-photo}`)"
-      # Following middleware will add a request header that will be displayed by photo to show route configuration
-      - "traefik.http.middlewares.${SUBDOMAIN:-photo}-https-shared-lan-private-path-headers.headers.customrequestheaders.X-Route-Info=entrypoint=lanwebsecure, router=${SUBDOMAIN:-photo}-https-shared-lan-private-path"
-      # Strip the prefix and add an X-Route-Info header
-      - "traefik.http.routers.${SUBDOMAIN:-photo}-https-shared-lan-private-path.middlewares=${SUBDOMAIN:-photo}-strip-prefix,${SUBDOMAIN:-photo}-https-shared-lan-private-path-headers"
-      # -----------------------------------------
+      # Strip the prefix
+      - "traefik.http.routers.${SUBDOMAIN:-photo}-http-private-path.middlewares=${SUBDOMAIN:-photo}-strip-prefix"
 
 
   ## Database Server (recommended)
@@ -196,7 +140,7 @@ services:
     command: --innodb-buffer-pool-size=512M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
     ## Never store database files on an unreliable device such as a USB flash drive, an SD card, or a shared network folder:
     volumes:
-      - "./database:/var/lib/mysql" # DO NOT REMOVE
+      - "db_data:/var/lib/mysql" # DO NOT REMOVE
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_INITDB_SKIP_TZINFO: "1"
@@ -218,3 +162,13 @@ networks:
   # It is not necessary for containers behind the reverse-proxy to expose their HTTP port to the host.
   traefik:
     external: true
+
+volumes:
+  photoprism_storage:
+     external:
+       name: {STORAGE_VOLUME:-photoprism_storage}
+  db_data:
+    external:
+      name: {DB_VOLUME:-photoprism_db_data}
+
+```

--- a/docker-compose/photoprism/docker-compose.yml
+++ b/docker-compose/photoprism/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - mariadb
     ## Server port mapping in the format "Host:Container". To use a different port, change the host port on
     ## the left-hand side and keep the container port, e.g. "80:2342" (for HTTP) or "443:2342 (for HTTPS):
+    networks:
+      - traefik
+      - backend
     ports:
       # TODO: Remove this line after debugging. Not needed to access behind Traefik
       - "2342:2342"
@@ -95,7 +98,7 @@ services:
     working_dir: "/photoprism" # do not change or remove
     ## Storage Folders: "~" is a shortcut for your home directory, "." for the current directory
     volumes:
-      - "${HUB_HOME_DIR}/media/photo:/photoprism/originals"  # Original media files (DO NOT REMOVE)
+      - "${HUB_HOME_DIR:-/home/vladsp}/media/photo:/photoprism/originals"  # Original media files (DO NOT REMOVE)
       # - "/example/family:/photoprism/originals/family"      # *Additional* media folders can be mounted like this
       # - "~/Import:/photoprism/import"                       # *Optional* base folder from which files can be imported to originals
       - "photoprism_storage:/photoprism/storage"              # *Writable* storage folder for cache, database, and sidecar files (DO NOT REMOVE)
@@ -138,6 +141,8 @@ services:
       - seccomp:unconfined
       - apparmor:unconfined
     command: --innodb-buffer-pool-size=512M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
+    networks:
+      - backend
     ## Never store database files on an unreliable device such as a USB flash drive, an SD card, or a shared network folder:
     volumes:
       - "db_data:/var/lib/mysql" # DO NOT REMOVE
@@ -151,7 +156,6 @@ services:
 
 
 networks:
-
   # The backend docker network used for traefik reverse-proxy request forwarding. All containers
   # that provide HTTP services behind the traefik reverse-proxy should be placed in
   # this network. traefik will route to the service on its exposed port, if there is exactly one, or port
@@ -162,6 +166,7 @@ networks:
   # It is not necessary for containers behind the reverse-proxy to expose their HTTP port to the host.
   traefik:
     external: true
+  backend: {}
 
 volumes:
   photoprism_storage:
@@ -170,5 +175,3 @@ volumes:
   db_data:
     external:
       name: {DB_VOLUME:-photoprism_db_data}
-
-```

--- a/docker-compose/photoprism/docker-compose.yml
+++ b/docker-compose/photoprism/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       PHOTOPRISM_ADMIN_PASSWORD: "insecure"          # initial admin password (8-72 characters)
       PHOTOPRISM_AUTH_MODE: "password"               # authentication mode (public, password)
       PHOTOPRISM_SITE_URL: "https://photo.sadovskyphoto.net"    # server URL in the format "http(s)://domain.name(:port)/(path)"
-      PHOTOPRISM_DISABLE_TLS: "false"                # disables HTTPS/TLS even if the site URL starts with https:// and a certificate is available
+      PHOTOPRISM_DISABLE_TLS: "true"                 # disables HTTPS/TLS even if the site URL starts with https:// and a certificate is available
       PHOTOPRISM_DEFAULT_TLS: "true"                 # defaults to a self-signed HTTPS/TLS certificate if no other certificate is available
       PHOTOPRISM_ORIGINALS_LIMIT: 5000               # file size limit for originals in MB (increase for high-res video)
       PHOTOPRISM_HTTP_COMPRESSION: "gzip"            # improves transfer speed and bandwidth utilization (none or gzip)

--- a/docker-compose/photoprism/docker-compose.yml
+++ b/docker-compose/photoprism/docker-compose.yml
@@ -171,7 +171,7 @@ networks:
 volumes:
   photoprism_storage:
      external:
-       name: {STORAGE_VOLUME:-photoprism_storage}
+       name: ${STORAGE_VOLUME:-photoprism_storage}
   db_data:
-    external:
-      name: {DB_VOLUME:-photoprism_db_data}
+     external:
+       name: ${DB_VOLUME:-photoprism_db_data}

--- a/docker-compose/photoprism/docker-compose.yml
+++ b/docker-compose/photoprism/docker-compose.yml
@@ -41,7 +41,8 @@ services:
     ## https://docs.photoprism.app/getting-started/config-options/
     environment:
       PHOTOPRISM_ADMIN_USER: "admin"                 # admin login username
-      PHOTOPRISM_ADMIN_PASSWORD: "insecure"          # initial admin password (8-72 characters)
+      PHOTOPRISM_ADMIN_PASSWORD: "${PHOTOPRISM_ADMIN_PASSWORD}"
+                                                     # initial admin password (8-72 characters)
       PHOTOPRISM_AUTH_MODE: "password"               # authentication mode (public, password)
       PHOTOPRISM_SITE_URL: "https://photo.sadovskyphoto.net"    # server URL in the format "http(s)://domain.name(:port)/(path)"
       PHOTOPRISM_DISABLE_TLS: "true"                 # disables HTTPS/TLS even if the site URL starts with https:// and a certificate is available


### PR DESCRIPTION
I fixed a number of issues:

1.  I cleaned up, fixed, and simplified the traefik rules. The whoami stack is unnecessarily complicated because it tries to display detailed routing info to the client.  It also unnecessarily supports http on public internet (cloudflare policy redirects http to https), and supports https on lan (there is no valid SSL key for lan so its only for testing).

2. The docker-compose stack was bind mounting /var/www on the hub host, rather than serving static content defined by the stack. This would defeat the purpose of deploying from github, since none of the static content would come from the repo and you would have to manually update /var/www outside of portainer (through ssh or something). This is legal but an antipattern for container-based services. I fixed it to do what I think is correct: The static content is included in the repo. The stack now has a Dockerfile that inherits from nginx:alpine, and copies ./www/html to /usr/share/nginx/html. The docker-compose.yml has a "build" property so the image is automatically built if necessary when the stack is started.

3. I destroyed and recreated the "www" stack in portainer and made it point to my fork of your homeserver repo.  Portainer has to be pointed at a git repo if you want artifacts other than docker-compose.yml (e.g., a Dockerfile and static web content) to be available to the stack.  After you incorporate this pull request, you should destroy the www stack and recreate it pointing to your own repo.